### PR TITLE
Make plan:{before,after}_{plan,test} bail on error

### DIFF
--- a/ddt
+++ b/ddt
@@ -283,7 +283,6 @@ ddt:format_test_name() {
 #   Returns according to `sed`.
 ddt:parse_trace_file() {
 	sed "${ddt[sedERE]}" "
-		1d;
 		s/^/    /;
 		\$s/(.*)/${ansi[magenta]}\1${ansi[reset]}/;
 	" "${1}"
@@ -368,27 +367,40 @@ ddt:summarise() {
 
 				ddt:parse_trace_file "${ddt['temp']}/${message}"
 				;;
+
+			# 599: Failing before/after-plan function
+			599)
+				(( tests[error]++ ))
+
+				name='ddt: before/after-plan function executes without error'
+
+				ddt:puts ' ' \
+					"${name}" \
+					"${ansi[grey]}${dots:$(( ${#name} + 10 ))}${ansi[reset]}" \
+					"${ansi[red]}[FAIL]${ansi[reset]}"
+
+				ddt:parse_trace_file "${ddt[temp]}/plan:before-after_plan"
+				;;
 		esac
 	done
 
-	(( tests[performed] + tests[skipped] > 0 )) && {
-		ddt:puts
-		printf '%s\n' "${ansi[bold]}--- ddt test results ---${ansi[reset]}"
+	ddt:puts
+	printf '%s\n' "${ansi[bold]}--- ddt test results ---${ansi[reset]}"
 
-		(( tests[performed] > 0 )) &&
-		tests[percent]="$(
-			awk \
-				-v "performed=${tests[performed]}" \
-				-v "passed=${tests[passed]}" \
-				'BEGIN { print int((passed / performed) * 100); }'
-		)"
+	(( tests[performed] > 0 )) &&
+	tests[percent]="$(
+		awk \
+			-v "performed=${tests[performed]}" \
+			-v "passed=${tests[passed]}" \
+			'BEGIN { print int((passed / performed) * 100); }'
+	)"
 
-		printf '%s: ' "${tests[performed]} test(s) performed"
-		printf '%s, ' "${tests[passed]} passed"
-		printf '%s, ' "${tests[failed]} failed"
-		printf '%s'   "${tests[percent]}% success"
-		printf '\n'
-	}
+	printf '%s: ' "${tests[performed]} test(s) performed"
+	printf '%s, ' "${tests[passed]} passed"
+	printf '%s, ' "${tests[failed]} failed"
+	printf '%s' "${tests[percent]}% success"
+	(( tests[error] )) && printf '; %s' "${tests[error]} error(s)"
+	printf '\n'
 
 	if (( tests[failed] > 0 )) || (( tests[error] > 0 )); then
 		return 1
@@ -577,14 +589,20 @@ ddt:main() {
 			}
 
 			(
-				plan:before_plan > /dev/null 2>&1
+				exec 3> "${ddt[temp]}/plan:before-after_plan"
+				{
+					set -xe
+					plan:before_plan
+					set +xe
+				} 1>&3 2>&1
+				exec 3>&-
 
 				while read -r _test; do
-					plan:before_test > /dev/null 2>&1
-
 					(
 						set -xe
+						plan:before_test
 						"${_test}"
+						plan:after_test
 					) > "${ddt[temp]}/${_test}" 2>&1
 
 					# Print pass/fail signal and test name
@@ -593,12 +611,19 @@ ddt:main() {
 					else
 						ddt:signal_result 500 "${_test}"
 					fi
-
-					plan:after_test > /dev/null 2>&1
 				done <<< "${plan[tests]}"
 
-				plan:after_plan > /dev/null 2>&1
+				exec 3> "${ddt[temp]}/plan:before-after_plan"
+				{
+					set -xe
+					plan:after_plan
+					set +xe
+				} 1>&3 2>&1
+				exec 3>&-
+
+				exit 0
 			)
+			(( $? )) && ddt:signal_result 599
 		)
 	done | ddt:summarise
 	return $?

--- a/tests/ddt.ddtt
+++ b/tests/ddt.ddtt
@@ -29,20 +29,20 @@ test:passes_lint_check() {
 
 # Make sure that `ddt -h` and `ddt --help` print long usage help text
 test:prints_long_usage_help_with_-h() {
-	"${0}" -h     | grep -iF 'options:' &&
-	"${0}" --help | grep -iF 'options:'
+	"${0}" -h     | grep -qiF 'options:' &&
+	"${0}" --help | grep -qiF 'options:'
 }
 
 # Make sure that `ddt -X` and `ddt --X` print brief usage help text
 test:prints_brief_usage_help_with_-h() {
-	"${0}" -X  2>&1 | grep -iF 'usage:' &&
-	"${0}" --X 2>&1 | grep -iF 'usage:'
+	"${0}" -X  2>&1 | grep -qiF 'usage:' &&
+	"${0}" --X 2>&1 | grep -qiF 'usage:'
 }
 
 # Make sure that `ddt` supports FIFO-based test plans
 test:correctly_handles_FIFO_plan() {
 	"${0}" <( printf '%s\n' 'test:foo() { :; }' ) 2>&1 |
-	grep -iE 'foo.*PASS'
+	grep -qiE 'foo.*PASS'
 }
 
 # Make sure that `ddt` gives an error when passed a file of invalid type


### PR DESCRIPTION
Fixes #5 

* All the before-/after-plan/test functions are subject to `set -xe` like test functions
* A failing before/after-plan function produces a new `FAIL` line and trace in the plan output, and counts as an error in the final result
* Before/after-test functions are executed in the same sub-shell with each test; if one fails, it causes the test to fail with it, and its trace is included in the output for said test
* Traces no longer omit the first line (previously the test function name, now sometimes the before-test function name)
* Unrelated to #5: I silenced the standard output of the self-test plan, just because it irritated me

After thinking about it a little more, i did not add `set -o pipefail`. It would make the self-test plan fail without further changes, and anyway it's easy enough to add to `plan:before_plan` where it's needed. (It will probably also work fine if you just add it to the top of the file, though you're not 'supposed' to)